### PR TITLE
Fix Korean translation in interface

### DIFF
--- a/src/components/Account/Modals.tsx
+++ b/src/components/Account/Modals.tsx
@@ -111,7 +111,7 @@ export const LanguageModal = memo(({ darkMode, isMobile, lang }: { darkMode: boo
                                 },
                                 {
                                     code: "ko",
-                                    name: "한국인"
+                                    name: "한국어"
                                 }
                             ].map((language) => {
                                 return (


### PR DESCRIPTION
'한국인' means Korean people, not Korean language. So, It must be '한국어' as I fix.