### PR TITLE
Allow arbitrary strings as passwords

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -39,18 +39,10 @@ const LoginForm = memo(({ windowWidth, darkMode, isMobile, lang }: AppBaseProps)
 
 		try {
 			let sEmail: string = email.trim()
-			let sPassword: string = password.trim()
+			let sPassword: string = password
 			let sTfa: string = tfa.trim()
 
-			if (!sEmail || !sPassword) {
-				toast.show("error", i18n(lang, "invalidEmailAndPassword"), "bottom", 5000)
-
-				setLoading(false)
-
-				return
-			}
-
-			if (sEmail.length == 0 || sPassword.length == 0) {
+			if (!sEmail || !sPassword || sEmail.length == 0 || sPassword.length == 0) {
 				toast.show("error", i18n(lang, "invalidEmailAndPassword"), "bottom", 5000)
 
 				setLoading(false)

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -114,18 +114,11 @@ const RegisterForm = memo(({ windowWidth, darkMode, isMobile, lang }: AppBasePro
 
 		try {
 			const userEmail: string = email.trim()
-			let userPassword: string = password.trim()
-			let userConfirmPassword: string = confirmPassword.trim()
+			let userPassword: string = password
+			let userConfirmPassword: string = confirmPassword
 
-			if (!userEmail || !userPassword || !userConfirmPassword) {
-				toast.show("error", i18n(lang, "invalidEmailAndPassword"), "bottom", 5000)
-
-				setLoading(false)
-
-				return
-			}
-
-			if (userEmail.length == 0 || userPassword.length == 0 || userConfirmPassword.length == 0) {
+			if (!userEmail || !userPassword || !userConfirmPassword
+				  || userEmail.length == 0 || userPassword.length == 0 || userConfirmPassword.length == 0) {
 				toast.show("error", i18n(lang, "invalidEmailAndPassword"), "bottom", 5000)
 
 				setLoading(false)


### PR DESCRIPTION
Cryptographically, there is no reason to exclude leading or trailing whitespace in a password if it is hashed or some key gen function is applied.